### PR TITLE
Investigate dashboard dark mode persistence issue

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,8 +1,8 @@
 import { Toaster } from "sonner";
 import "../styles/globals.css";
-import { ThemeModeScript } from "flowbite-react";
 import NextTopLoader from "nextjs-toploader";
 import { I18nProvider } from "@/i18n/I18nProvider";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 export const metadata = {
   title: "インベンチュラ",
@@ -68,16 +68,21 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <head>
-        <ThemeModeScript />
-      </head>
       <body>
-        {/* i18n provider wraps everything */}
-        <I18nProvider>
-          {children}
-          <Toaster position="top-center" richColors />
-          <NextTopLoader />
-        </I18nProvider>
+        {/* Theme provider wraps everything */}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {/* i18n provider wraps everything */}
+          <I18nProvider>
+            {children}
+            <Toaster position="top-center" richColors />
+            <NextTopLoader />
+          </I18nProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/DarkModeToggle.jsx
+++ b/src/components/DarkModeToggle.jsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export default function DarkModeToggle({ className = "" }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <button
+        className={`inline-flex items-center justify-center rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-2 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 ${className}`}
+        disabled
+      >
+        <Sun className="h-4 w-4" />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className={`inline-flex items-center justify-center rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-2 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${className}`}
+      aria-label="Toggle dark mode"
+    >
+      {theme === "dark" ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </button>
+  );
+}

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children, ...props }) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/features/auth/components/AuthHeader.jsx
+++ b/src/features/auth/components/AuthHeader.jsx
@@ -1,7 +1,7 @@
 // components/AuthHeader.jsx
 import React from "react";
 import Link from "next/link";
-import { DarkThemeToggle } from "flowbite-react";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import InventuraMark from "@/components/InventuraMark";
 import LangToggle, { LangToggleIcon } from "@/components/LangToggle";
 import { useI18n } from "@/i18n/I18nProvider";
@@ -22,7 +22,7 @@ const AuthHeader = () => {
       </Link>
       <div className="flex gap-3">
         <LangToggle className="rounded-xl text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 border-gray-300 dark:border-gray-700" />
-        <DarkThemeToggle />
+        <DarkModeToggle />
       </div>
     </div>
   );

--- a/src/features/dashboard/components/DashBoardHeader.jsx
+++ b/src/features/dashboard/components/DashBoardHeader.jsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { DarkThemeToggle } from "flowbite-react";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import {
   Bell,
   Search,
@@ -73,7 +73,7 @@ const DashBoardHeader = ({ onOpenSidebar, brand = "Inventura" }) => {
 
             {/* Theme toggle */}
             <div className="block">
-              <DarkThemeToggle />
+              <DarkModeToggle />
             </div>
 
             {/* Profile menu — fix label width to avoid EN/JA shift */}

--- a/src/features/profile/components/ProfileMobile.jsx
+++ b/src/features/profile/components/ProfileMobile.jsx
@@ -11,7 +11,7 @@ import {
   Loader2,
   ArrowLeft,
 } from "lucide-react";
-import { DarkThemeToggle } from "flowbite-react";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import { useState } from "react";
 import {
   storeProfileImage,
@@ -107,7 +107,7 @@ const ProfileMobile = ({ profileData, onOpenPasswordModal }) => {
             {t("profile.title", "ユーザープロフィール")}
           </h1>
           <div className="flex items-center gap-2">
-            <DarkThemeToggle className="border text-white dark:text-white" />
+            <DarkModeToggle className="border text-white dark:text-white" />
             <LangToggle className="px-2 py-3 rounded-lg text-white border dark:border-gray-300" />
           </div>
         </div>

--- a/src/features/profile/components/ProfleDesktop.jsx
+++ b/src/features/profile/components/ProfleDesktop.jsx
@@ -11,7 +11,7 @@ import {
   Loader2,
   ArrowLeft,
 } from "lucide-react";
-import { DarkThemeToggle } from "flowbite-react";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import { useState } from "react";
 import {
   storeProfileImage,
@@ -125,7 +125,7 @@ const ProfileDesktop = ({ profileData, onOpenPasswordModal }) => {
             {/* Lang Toggle */}
             <LangToggle text="text-blue-600" className="rounded-xl bg-white/90  hover:bg-white px-3 py-2 text-sm font-medium transition" />
             {/* Dark Mode Toggle */}
-            <DarkThemeToggle className="border text-white dark:text-white " />
+            <DarkModeToggle className="border text-white dark:text-white " />
           </div>
         </div>
       </div>

--- a/src/features/static/components/Header.jsx
+++ b/src/features/static/components/Header.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import Link from "next/link";
 import { Menu, X, Languages } from "lucide-react";
-import { DarkThemeToggle } from "flowbite-react";
+import DarkModeToggle from "@/components/DarkModeToggle";
 import InventuraMark from "@/components/InventuraMark";
 import { useI18n } from "@/i18n/I18nProvider";
 import LangToggle from "@/components/LangToggle";
@@ -46,7 +46,7 @@ export default function Header() {
         {/* Right: toggles + auth */}
         <div className="hidden md:flex items-center space-x-4">
           <LangToggle className="rounded-xl bg-gray-100  dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-700 border border-gray-600 dark:border-gray-300" />
-          <DarkThemeToggle />
+          <DarkModeToggle />
           <Link
             href="/login"
             className="px-4 py-2 w-25 text-center text-sm font-semibold rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-300 transform hover:scale-105"
@@ -60,7 +60,7 @@ export default function Header() {
             {t("landing.auth.register", "登録")}
           </Link>
         </div>
-        <DarkThemeToggle className="md:hidden" />
+        <DarkModeToggle className="md:hidden" />
         <LangToggle className="rounded-xl md:hidden bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 border-gray-300 dark:border-gray-700" />
         {/* Mobile: menu button */}
         <button


### PR DESCRIPTION
Implement `next-themes` for dark mode persistence to resolve inconsistent behavior on the dashboard page.

The project had `next-themes` installed but was using Flowbite's `DarkThemeToggle` without a proper theme provider. This led to inconsistent dark mode behavior and lack of persistence, particularly on the `/dashboard` route. This PR establishes `next-themes` as the sole theme management solution, ensuring consistent and persistent dark mode across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cb28e38-2b3a-4a21-964b-e57bb0d4df5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cb28e38-2b3a-4a21-964b-e57bb0d4df5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

